### PR TITLE
fix: ensure accent text changes with the theme

### DIFF
--- a/src/jagt/app.py
+++ b/src/jagt/app.py
@@ -217,8 +217,8 @@ class CommitMessageView(VerticalScroll):
     commit_details: var[CommitDetails | None] = var(None)
 
     def compose(self) -> ComposeResult:
-        yield Static(id="--subject")
-        yield Static(id="--body")
+        yield Static(id="--subject", markup=False)
+        yield Static(id="--body", markup=False)
 
     def watch_commit_details(self) -> None:
         commit = self.commit_details


### PR DESCRIPTION
When the app theme changes, the accent color to highlight the commit hash should also change accordingly.

This doesn't work with Rich renderables and component classes, as discussed in https://github.com/Textualize/textual/discussions/5502. We can simplify some widgets by splitting the text content into separate `Static` children, and also utilize the new `Content` object added in Textual v2.0.