### PR TITLE
refactor: add default mode

### DIFF
--- a/src/jagt/app.py
+++ b/src/jagt/app.py
@@ -393,14 +393,13 @@ class JagtApp(App):
         "log": LogScreen,
     }
 
+    DEFAULT_MODE = "log"
+
     CSS = """
     * {
         scrollbar-size-vertical: 1;
     }
     """
-
-    def on_mount(self) -> None:
-        self.switch_mode("log")
 
 
 def run() -> None:


### PR DESCRIPTION
Set the `DEFAULT_MODE` in the app rather than the old way of switching the mode on mount.